### PR TITLE
Transform SKÅDIS generator into hollow cylinder generator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+```bash
+npm run dev      # Start development server with Vite
+npm run build    # TypeScript compilation and production build
+npm run tsc      # Run TypeScript compiler only
+npm run format   # Format code with Prettier
+```
+
+## Architecture Overview
+
+SKÅPA is a web application for generating customizable 3D printable models for IKEA SKÅDIS pegboards. The application uses a sophisticated 3D rendering pipeline and computational geometry.
+
+### Core Technologies
+- **Manifold-3d**: WebAssembly-based 3D geometry engine for generating parametric models
+- **Three.js**: 3D rendering with custom outline effects
+- **Twrl**: Custom JSX-like syntax for DOM manipulation (uses `jsx: "react-jsx"` with `jsxImportSource: "twrl"`)
+- **Vite**: Build system and development server
+- **TypeScript**: Strict typing with path aliases (`@src/*` maps to `src/*`)
+
+### Key Architecture Components
+
+#### 3D Model Generation (`src/model/`)
+- `manifold.ts`: Core geometry generation using Manifold WebAssembly
+  - `box()`: Main function that generates complete model with clips
+  - `base()`: Generates hollow box structure
+  - `clips()`: Generates SKÅDIS-compatible clips with optional chamfering
+  - All dimensions in millimeters, clips are 12mm height (`CLIP_HEIGHT`)
+
+#### Rendering Pipeline (`src/rendering/`)
+- `renderer.ts`: Custom Three.js renderer with orthographic camera and post-processing
+- `effects/outline/`: Custom outline rendering for technical drawing aesthetic
+- `effects/thicken/`: Line thickening pass for better visibility
+- `effects/antialiasing.ts`: FXAA antialiasing
+- Uses EffectComposer for multi-pass rendering pipeline
+
+#### Interactive Controls (`src/controls.tsx`)
+- `rangeControl()`: Slider + number input combination
+- `stepper()`: Plus/minus button controls for discrete values
+- Uses Twrl JSX syntax for DOM generation
+
+#### State Management (`src/main.ts`)
+- Uses custom `Dyn` reactive system from twrl library
+- `modelDimensions`: Core model parameters (height, width, depth, radius, wall, bottom)
+- `animations`: Animated versions of dimensions for smooth transitions
+- `partPositioning`: Interactive rotation state machine
+
+### Animation System
+- Custom `Animate` class for smooth parameter transitions
+- Three states for part rotation: "static", "will-move", "moving"
+- Camera auto-centering with overflow calculations for responsive layout
+- Real-time geometry regeneration on parameter changes
+
+### File Export
+- Uses `@jscadui/3mf-export` for 3MF file generation
+- Background model loading with `TMFLoader` class
+- Models named as `skapa-{width}-{depth}-{height}.3mf`
+
+### Development Notes
+- Uses path aliases: `@src/*` maps to `src/*`
+- Three.js coordinate system aligned with 3D printer (Z-up): `THREE.Object3D.DEFAULT_UP = new THREE.Vector3(0, 0, 1)`
+- Strict TypeScript with unused parameter/local checking enabled
+- All geometry calculations assume millimeter units

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <meta property="og:title" content="SKÅPA" />
+    <meta property="og:title" content="Hollow Cylinder Generator" />
     <meta property="og:type" content="website" />
     <meta
       name="description"
-      content="3D printable model generator for IKEA SKÅDIS"
+      content="3D printable hollow cylinder generator"
     />
     <meta
       property="og:description"
-      content="3D printable model generator for IKEA SKÅDIS"
+      content="3D printable hollow cylinder generator"
     />
 
     <meta property="og:url" content="https://skapa.build" />
@@ -25,11 +25,11 @@
       href="https://fonts.googleapis.com/css2?family=Kanit:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
       rel="stylesheet"
     />
-    <title>IKEA SKÅDIS Models</title>
+    <title>Hollow Cylinder Generator</title>
   </head>
   <body>
     <header>
-      <h1>SKÅPA</h1>
+      <h1>Hollow Cylinder Generator</h1>
     </header>
     <section>
       <div id="part">

--- a/src/model/manifold.ts
+++ b/src/model/manifold.ts
@@ -1,11 +1,9 @@
-import type { Vec2, Vec3, CrossSection, Manifold } from "manifold-3d";
+import type { Vec2, CrossSection, Manifold } from "manifold-3d";
 import type { ManifoldToplevel } from "manifold-3d";
 import init from "manifold-3d";
 import manifold_wasm from "manifold-3d/manifold.wasm?url";
 
 // NOTE: all values are in mm
-
-export const CLIP_HEIGHT = 12;
 
 // Load manifold 3d
 class ManifoldModule {
@@ -22,152 +20,37 @@ class ManifoldModule {
   }
 }
 
-// Generates a CCW arc (quarter)
-function generateArc({
-  center,
-  radius,
-}: {
-  center: Vec2;
-  radius: number;
-}): Vec2[] {
-  // Number of segments (total points - 2)
-  const N_SEGMENTS = 10;
-  const N_POINTS = N_SEGMENTS + 2;
+// Creates a circle cross-section centered at (0,0)
+async function circle(radius: number): Promise<CrossSection> {
+  const { CrossSection } = await ManifoldModule.get();
+  const N_SEGMENTS = 64; // High resolution for smooth circle
 
-  const pts: Vec2[] = [];
-  for (let i = 0; i < N_POINTS; i++) {
-    const angle = (i * (Math.PI / 2)) / (N_POINTS - 1);
-
-    pts.push([
-      center[0] + radius * Math.cos(angle),
-      center[1] + radius * Math.sin(angle),
+  const vertices: Vec2[] = [];
+  for (let i = 0; i < N_SEGMENTS; i++) {
+    const angle = (i * 2 * Math.PI) / N_SEGMENTS;
+    vertices.push([
+      radius * Math.cos(angle),
+      radius * Math.sin(angle),
     ]);
   }
-
-  return pts;
-}
-
-// Rounded rect centered at (0,0)
-async function roundedRectangle(
-  size: Vec2,
-  cornerRadius: number,
-): Promise<CrossSection> {
-  const { CrossSection } = await ManifoldModule.get();
-  const w = size[0];
-  const h = size[1];
-  const basicArc = generateArc({
-    center: [w / 2 - cornerRadius, h / 2 - cornerRadius],
-    radius: cornerRadius,
-  });
-
-  // Reuse the basic arc and mirror & reverse as necessary for each corner of
-  // the cube
-  const topRight: Vec2[] = basicArc;
-  const topLeft: Vec2[] = Array.from(basicArc.map(([x, y]) => [-x, y]));
-  topLeft.reverse();
-  const bottomLeft: Vec2[] = basicArc.map(([x, y]) => [-x, -y]);
-  const bottomRight: Vec2[] = Array.from(basicArc.map(([x, y]) => [x, -y]));
-  bottomRight.reverse();
-
-  const vertices: Vec2[] = [
-    ...topRight,
-    ...topLeft,
-    ...bottomLeft,
-    ...bottomRight,
-  ];
 
   return new CrossSection(vertices);
 }
 
-async function clipRCrossSection(): Promise<CrossSection> {
-  const { CrossSection } = await ManifoldModule.get();
-
-  const vertices: Vec2[] = [
-    [0.95, 0],
-    [2.45, 0],
-    [2.45, 3.7],
-    [3.05, 4.3],
-    [3.05, 5.9],
-    [2.45, 6.5],
-    [0.95, 6.5],
-    [0.95, 0],
-  ];
-
-  return new CrossSection(vertices).rotate(180);
-}
-
-// The skadis clips, starting at the origin and pointing in -Z
-// If chamfer is true, the bottom of the clip has a 45 deg chamfer
-// (to print without supports)
-export async function clips(
-  chamfer: boolean = false,
-): Promise<[Manifold, Manifold]> {
-  const clipR = (await clipRCrossSection()).extrude(CLIP_HEIGHT);
-  const clipL = (await clipRCrossSection()).mirror([1, 0]).extrude(CLIP_HEIGHT);
-
-  if (!chamfer) {
-    return [clipR, clipL];
-  }
-
-  const n: Vec3 = [0, 1, 1]; /* a 45deg normal defining the trim plane */
-  return [clipR.trimByPlane(n, 0), clipL.trimByPlane(n, 0)];
-}
-
-// The box (without clips) with origin in the middle of the bottom face
-export async function base(
+// Creates a hollow cylinder with origin at the center of the bottom face
+export async function hollowCylinder(
   height: number,
-  width: number,
-  depth: number,
-  radius: number,
-  wall: number,
-  bottom: number,
+  outerRadius: number,
+  wallThickness: number,
 ): Promise<Manifold> {
-  const innerRadius = Math.max(0, radius - wall);
-  const outer = (await roundedRectangle([width, depth], radius)).extrude(
-    height,
-  );
-  const innerNeg = (
-    await roundedRectangle([width - 2 * wall, depth - 2 * wall], innerRadius)
-  )
-    .extrude(height - bottom)
-    .translate([0, 0, bottom]);
+  const innerRadius = Math.max(0, outerRadius - wallThickness);
 
-  return outer.subtract(innerNeg);
-}
+  // Create outer cylinder
+  const outer = (await circle(outerRadius)).extrude(height);
 
-// The box (with clips), with origin where clips meet the box
-export async function box(
-  height: number,
-  width: number,
-  depth: number,
-  radius: number,
-  wall: number,
-  bottom: number,
-): Promise<Manifold> {
-  const padding = 5; /* mm */
-  const W = width - 2 * radius - 2 * padding; // Working area
-  const gw = 40; // (horizontal) gap between clip origins
-  const N = Math.floor(W / gw + 1); // How many (pairs of) clips we can fit
-  const M = N - 1;
-  const dx = ((-1 * M) / 2) * gw; // where to place the clips
+  // Create inner cylinder (hollow part)
+  const inner = (await circle(innerRadius)).extrude(height);
 
-  // Same as horizontal, but vertically (slightly simpler because we always start
-  // from 0 and we don't need to take the radius into account)
-  const H = height - CLIP_HEIGHT; // Total height minus clip height
-  const gh = 40;
-  const NV = Math.floor(H / gh + 1);
-
-  let res = await base(height, width, depth, radius, wall, bottom);
-
-  for (let i = 0; i < N; i++) {
-    for (let j = 0; j < NV; j++) {
-      // For all but the first level, chamfer the clips
-      const chamfer = j > 0;
-      const [clipL, clipR] = await clips(chamfer);
-      res = res.add(clipL.translate(i * gw + dx, -depth / 2, j * gh));
-      res = res.add(clipR.translate(i * gw + dx, -depth / 2, j * gh));
-    }
-  }
-
-  return res;
+  // Subtract inner from outer to create hollow cylinder
+  return outer.subtract(inner);
 }


### PR DESCRIPTION
## Summary
- Complete transformation from SKÅDIS pegboard accessory generator to parametric hollow cylinder generator
- Simplified UI with three key parameters: height, outer radius, and wall thickness
- Replaced complex SKÅDIS clip geometry with clean circular geometry using manifold-3d

## Changes
- **Model Generation**: Replaced `box()` function with `hollowCylinder()` function in `manifold.ts`
- **UI Controls**: Updated from levels/width/depth controls to height/radius/thickness controls
- **State Management**: Simplified dimension parameters and removed SKÅDIS-specific logic
- **Branding**: Updated HTML titles and descriptions to reflect new purpose
- **Documentation**: Added comprehensive CLAUDE.md for future development

## Test plan
- [x] TypeScript compilation passes
- [x] Application builds successfully 
- [x] UI controls generate appropriate parameter ranges
- [x] 3MF export functionality maintained with new naming convention

🤖 Generated with [Claude Code](https://claude.ai/code)